### PR TITLE
Fix deprecated file test operator  -a  in generate_database.sh

### DIFF
--- a/generate_database.sh
+++ b/generate_database.sh
@@ -1,4 +1,4 @@
-if [ -a "metrolink.db" ]; then
+if [ -e "metrolink.db" ]; then
   echo "wiping the existing database"
   rm metrolink.db
 fi


### PR DESCRIPTION
Change the deprecated file test operator  -a  to  -e  in the first line of generate_database.h
This doesn't change the function of the script.  Just keepin' up with the Joneses.

source  http://tldp.org/LDP/abs/html/fto.html
